### PR TITLE
docs(quickstart): missing step

### DIFF
--- a/QuickStart.md
+++ b/QuickStart.md
@@ -25,6 +25,7 @@ Clone your own private repository and add Klarna upstream to pull updates from (
 
 ```sh
 git clone <your private repo>
+cd <local gram folder>
 git remote add github https://github.com/klarna-incubator/gram.git
 ```
 


### PR DESCRIPTION
More like educational step for me while getting used to Gram. Minor adjustments to quickstart markdown guidance :D 

**What's changed?**
- added missing step 