### PR TITLE
Minor fixes and review score in bottom panel

### DIFF
--- a/app/src/components/model/panels/bottom/BottomPanel.js
+++ b/app/src/components/model/panels/bottom/BottomPanel.js
@@ -6,7 +6,6 @@ import { useState, useEffect } from "react";
 import { useModelID } from "../../hooks/useModelID";
 import { useSelectedComponent } from "../../hooks/useSelectedComponent";
 import { useValidateQuery } from "../../../../api/gram/validation";
-import { COMPONENT_TYPE } from "../../board/constants";
 
 export function BottomPanel() {
   const modelId = useModelID();
@@ -39,6 +38,12 @@ export function BottomPanel() {
         )
       : [];
   }
+
+  const passedResults = validationResults.filter((result) => result.testResult);
+  const successRatio =
+    validationResults.length === 0
+      ? 0
+      : Number((passedResults.length / validationResults.length).toFixed(2));
 
   if (tab === 0) {
     // TAB.ALL
@@ -78,6 +83,7 @@ export function BottomPanel() {
             modelLength={modelResults.length}
             selectedLength={selectedResults.length}
             selectedComponent={selectedComponent}
+            successRatio={successRatio}
           />
           <ValidationTab
             tab={tab}

--- a/app/src/components/model/panels/bottom/BottomPanel.js
+++ b/app/src/components/model/panels/bottom/BottomPanel.js
@@ -6,6 +6,7 @@ import { useState, useEffect } from "react";
 import { useModelID } from "../../hooks/useModelID";
 import { useSelectedComponent } from "../../hooks/useSelectedComponent";
 import { useValidateQuery } from "../../../../api/gram/validation";
+import { COMPONENT_TYPE } from "../../board/constants";
 
 export function BottomPanel() {
   const modelId = useModelID();
@@ -57,16 +58,15 @@ export function BottomPanel() {
   }
 
   useEffect(() => {
-    if (!selectedComponent) {
+    if (!selectedComponent && tab === TAB.SELECTED_COMPONENT) {
       setTab(0);
-    } else {
-      setTab(2);
     }
-  }, [selectedComponent]);
+  }, [selectedComponent, tab]);
 
   if (bottomPanelCollapsed) {
     return <></>;
   }
+
   return (
     <Box sx={{ gridArea: "bottom", backgroundColor: "rgb(20,20,20)" }}>
       {!isLoading && (
@@ -77,12 +77,14 @@ export function BottomPanel() {
             allLength={allNegativeResults.length}
             modelLength={modelResults.length}
             selectedLength={selectedResults.length}
+            selectedComponent={selectedComponent}
           />
           <ValidationTab
             tab={tab}
             setTab={setTab}
             filteredResults={filteredResults}
             isLoading={isLoading}
+            selectedComponent={selectedComponent}
           />
         </>
       )}

--- a/app/src/components/model/panels/bottom/BottomTabsHeader.js
+++ b/app/src/components/model/panels/bottom/BottomTabsHeader.js
@@ -25,6 +25,15 @@ function getBadgeColor(length) {
   return "error";
 }
 
+function getSuccessRatioColor(ratio) {
+  if (ratio >= 0.75) {
+    return "success";
+  } else if (ratio >= 0.5) {
+    return "warning";
+  }
+  return "error";
+}
+
 export function BottomTabsHeader({
   tab,
   setTab,
@@ -32,6 +41,7 @@ export function BottomTabsHeader({
   modelLength,
   selectedLength,
   selectedComponent,
+  successRatio,
 }) {
   return (
     <Paper elevation={3} sx={{ display: "flex" }}>
@@ -39,6 +49,7 @@ export function BottomTabsHeader({
         sx={{
           mx: 3,
           display: "flex",
+          gap: 1,
           justifyContent: "center",
           alignItems: "center",
         }}
@@ -46,6 +57,12 @@ export function BottomTabsHeader({
         <Typography variant="h6" sx={{ fontSize: "0.8rem" }}>
           QUALITY CHECK
         </Typography>
+        <Badge
+          showZero
+          badgeContent={`${successRatio * 100}%`}
+          color={getSuccessRatioColor(successRatio)}
+          sx={tabBadgeStyle}
+        ></Badge>
       </Box>
       <Box sx={{ flexGrow: 1 }}>
         <Grow in={true}>

--- a/app/src/components/model/panels/bottom/BottomTabsHeader.js
+++ b/app/src/components/model/panels/bottom/BottomTabsHeader.js
@@ -1,5 +1,4 @@
 import { Paper, Grow, Tab, Tabs, Badge, Typography, Box } from "@mui/material";
-import { useSelectedComponent } from "../../hooks/useSelectedComponent";
 
 export const TAB = {
   ALL: 0,
@@ -32,12 +31,8 @@ export function BottomTabsHeader({
   allLength,
   modelLength,
   selectedLength,
+  selectedComponent,
 }) {
-  const selected = useSelectedComponent();
-
-  // This fixes an annoying MUI console error when you deselect a component
-  const tabHck = !selected && tab === TAB.COMPONENT ? TAB.SYSTEM : tab;
-
   return (
     <Paper elevation={3} sx={{ display: "flex" }}>
       <Box
@@ -55,7 +50,7 @@ export function BottomTabsHeader({
       <Box sx={{ flexGrow: 1 }}>
         <Grow in={true}>
           <Tabs
-            value={tabHck}
+            value={tab}
             onChange={(_, v) => setTab(v)}
             textColor="inherit"
             variant="fullWidth"
@@ -97,7 +92,7 @@ export function BottomTabsHeader({
               }
               value={TAB.MODEL}
             />
-            {selected && (
+            {selectedComponent && (
               <Tab
                 disableRipple
                 label={

--- a/app/src/components/model/panels/bottom/ValidationTab.js
+++ b/app/src/components/model/panels/bottom/ValidationTab.js
@@ -11,7 +11,6 @@ import DoneIcon from "@mui/icons-material/Done";
 import CloseIcon from "@mui/icons-material/Close";
 import { useSetSelected } from "../../hooks/useSetSelected";
 import { useDeselectAll } from "../../hooks/useSetMultipleSelected";
-import { useSelectedComponent } from "../../hooks/useSelectedComponent";
 
 function selectElement(type, elementId, setSelected, deselectAll, setTab) {
   deselectAll();
@@ -74,11 +73,15 @@ function renderResults(results, setSelected, deselectAll, setTab) {
   });
 }
 
-export function ValidationTab({ tab, setTab, filteredResults, isLoading }) {
+export function ValidationTab({
+  tab,
+  setTab,
+  filteredResults,
+  isLoading,
+  selectedComponent,
+}) {
   const setSelected = useSetSelected();
   const deselectAll = useDeselectAll();
-
-  const selectedComponent = useSelectedComponent();
 
   if (isLoading) {
     return (

--- a/core/src/validation/engine.spec.ts
+++ b/core/src/validation/engine.spec.ts
@@ -143,4 +143,42 @@ describe("ValidationEngine", () => {
     expect(resultList.length).toBe(1);
     expect(resultList[0].ruleName).toBe("should be selected");
   });
+
+  it("should select appropriate component rules based on affectedType", async () => {
+    validationEngine.register([
+      {
+        type: "component",
+        name: "should apply to all components",
+        affectedType: [],
+        test: async ({ component }) => {
+          return false;
+        },
+        messageTrue: "should never be true",
+        messageFalse: "Yep, it applied to all components",
+      },
+      {
+        type: "component",
+        name: "should apply to external entity only",
+        affectedType: ["ee"],
+        test: async ({ component }) => {
+          return false;
+        },
+        messageTrue: "should never be true",
+        messageFalse: "Yep, it applied to external entity only",
+      },
+    ]);
+
+    const modelId = await createSampleModel(dal);
+    const resultList = await validationEngine.getResults(modelId);
+    const applyAllResult = resultList.filter((r) => {
+      return r.ruleName === "should apply to all components";
+    });
+    const applyEEOnlyResult = resultList.filter((r) => {
+      return r.ruleName === "should apply to external entity only";
+    });
+
+    expect(applyAllResult.length).toBe(2);
+    expect(applyEEOnlyResult.length).toBe(1);
+    expect(applyEEOnlyResult[0].elementName).toBe("omegalul");
+  });
 });

--- a/core/src/validation/engine.ts
+++ b/core/src/validation/engine.ts
@@ -180,6 +180,14 @@ export class ValidationEngine extends EventEmitter {
             }
           }
         }
+
+        // Skip the rule if the component type is not in the affectedType array
+        if (rule.affectedType.length > 0) {
+          if (!rule.affectedType.includes(component.type)) {
+            continue;
+          }
+        }
+
         try {
           const testResult = await rule.test({
             ...ruleArgs,


### PR DESCRIPTION
Bugs:
- [Core] Validation engine does not consider the affectedType when selecting rules for a model.
- [App] When a dataflow is selected, user cannot navigate between the tabs of the bottom panel

Improvement needed:
- [App] Review score is only available when requesting a review

Fixes:
- [Core] Validation engines skips rules based on affectedType for component rules
- [App] When a dataflow is selected, user can navigate between the tabs of the bottom panel. However, when a component is selected, the SELECTED_COMPONENT tab is no longer automatically selected.

Feature:
- [App] Review score is displayed in the bottom panel next to QUALITY CHECK.