### PR TITLE
fix: :bug: fix validation on resource-matching api routes

### DIFF
--- a/api/src/resources/gram/v1/resource-matching/create.ts
+++ b/api/src/resources/gram/v1/resource-matching/create.ts
@@ -12,11 +12,15 @@ export function createResourceMatching(dal: DataAccessLayer) {
     const { modelId } = req.params;
     const { user } = req;
 
-    if (!validateUUID(modelId) || !validateUUID(resourceId)) {
+    if (!validateUUID(modelId)) {
       throw new NotFoundError();
     }
 
     if (componentId !== null && !validateUUID(componentId)) {
+      throw new NotFoundError();
+    }
+
+    if (!resourceId) {
       throw new NotFoundError();
     }
 

--- a/api/src/resources/gram/v1/resource-matching/delete.ts
+++ b/api/src/resources/gram/v1/resource-matching/delete.ts
@@ -11,11 +11,15 @@ export function deleteResourceMatching(dal: DataAccessLayer) {
     const { modelId } = req.params;
     const { user } = req;
 
-    if (!validateUUID(modelId) || !validateUUID(resourceId)) {
+    if (!validateUUID(modelId)) {
       throw new NotFoundError();
     }
 
     if (componentId !== null && !validateUUID(componentId)) {
+      throw new NotFoundError();
+    }
+
+    if (!resourceId) {
       throw new NotFoundError();
     }
 

--- a/app/src/components/model/panels/left/ComponentTab.js
+++ b/app/src/components/model/panels/left/ComponentTab.js
@@ -189,7 +189,6 @@ export function MatchComponentWithResource({
 }) {
   const [resourceInput, setResourceInput] = useState(null);
   const [createMatching] = useCreateMatchingMutation();
-  console.log({ resources, modelId, component });
 
   const filteredResources = resources
     ? resources?.filter((r) => {

--- a/app/src/components/model/panels/left/ResourceFilter.js
+++ b/app/src/components/model/panels/left/ResourceFilter.js
@@ -9,7 +9,6 @@ import CloseIcon from "@mui/icons-material/Close";
 import { GROUP_BY } from "./ResourceTab";
 function toggleGroupBy(groupBy, setGroupBy, value) {
   if (groupBy === value) {
-    console.log("should reset to null");
     setGroupBy(null);
   } else {
     setGroupBy(value);

--- a/app/src/components/model/panels/left/ResourceList.js
+++ b/app/src/components/model/panels/left/ResourceList.js
@@ -355,12 +355,6 @@ function MatchResourceWithComponent({
 
   function handleChange(e) {
     if (e.target.value === null) {
-      console.log("Ignore this resource", {
-        modelId: modelId,
-        resourceId: resource.id,
-        componentId: null,
-      });
-
       createMatching({
         modelId: modelId,
         resourceId: resource.id,


### PR DESCRIPTION
The validation of resourceId on the create and delete endpoints is too strict.

Fix:
- validation only checks that the resourceId is provided