### PR TITLE
feat(api): raise JSON import body limit and add threat-model authoring guide for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,51 @@ The import handler enforces a **10 MB** limit on the payload (`importJson.ts`). 
 
 For large models, reduce verbose descriptions or remove the optional `aiInstructions` block from `metadata` before importing. A safe rule of thumb: descriptions truncated to 350 characters and no `aiInstructions` will keep a 40-threat / 60-control model well under the limit.
 
+### Discovering and assigning component classes
+
+Each component can carry a `classes` array that links it to a tech-stack icon and drives threat/control suggestions from the plugin library. Use the catalog script to discover every available class:
+
+```bash
+# List all classes (table)
+python3 scripts/list-component-classes.py
+
+# Filter by keyword
+python3 scripts/list-component-classes.py --filter secrets
+
+# Restrict to one plugin
+python3 scripts/list-component-classes.py --plugin aws
+
+# Output as JSON for scripting
+python3 scripts/list-component-classes.py --format json
+```
+
+**Commonly needed classes (quick reference)**
+
+| Class name | ID | Plugin | Typical use |
+|---|---|---|---|
+| `AWS` | `6f860ca0-d093-462e-8724-345de463917d` | aws | Generic AWS resource |
+| `AWS Secrets Manager` | `764ac511-e39b-499b-a8ee-7cac43ac72dc` | aws | Secrets store |
+| `AWS Systems Manager` | `c0d9c5bc-04b7-4a71-bf14-38dc104b1607` | aws | SSM Parameter Store |
+| `Amazon RDS` | `f313446f-d8b1-435d-b406-40f3b5d1b4ef` | aws | Relational database |
+| `Amazon S3 Standard` | `b40ebed3-46cd-41b7-a956-cfd23ce25a4e` | aws | Object storage |
+| `AWS Lambda` | `ef220954-5701-4a7c-8dae-416b8d5d8536` | aws | Serverless function |
+| `Amazon EC2` | `892eb7eb-3ed7-452e-9d57-4dd06c25b65d` | aws | Virtual machine |
+| `AWS Identity and Access Management` | `5c49ceab-723b-4911-902d-78588bc3af4c` | aws | IAM |
+| `Azure Active Directory` | `7e0c3809-64f4-4402-8f72-35cb214ab798` | azure | Microsoft Entra ID / AAD |
+| `Microsoft Azure` | `39032a3c-d160-412c-8d75-7064cc4362a5` | svgporn | Azure-hosted SaaS |
+| `Microsoft` | `7ea205a0-8256-44e2-bb18-3bf37d685bde` | svgporn | Microsoft product/service |
+| `Microsoft Windows` | `3fc8b4c6-0821-4f4d-9890-fb72f5e043b4` | svgporn | Windows endpoint |
+| `Microsoft Teams` | `d3d4e92b-a71e-4eaf-8588-ad13cebd52ca` | svgporn | Teams collaboration |
+| `Google Workspace` | `d3d98298-1600-4f36-9ed6-d0e688d4d8f6` | svgporn | Google Workspace |
+| `Google Drive` | `b9a59d2f-0960-4195-8593-0684cf825544` | svgporn | Google Drive |
+| `slack` | `8f937e72-4c0e-4774-a79b-a4b6268a2f6f` | svgporn | Slack |
+| `docker` | `ec2b239c-e9ac-4b6e-bb38-acd636d71269` | svgporn | Docker container |
+| `Python` | `761c167b-b742-4baa-a6cb-9e2ea2530b1e` | svgporn | Python service |
+| `Kafka` | `7452d79f-fa2a-49bf-a739-46bfe6af2c77` | svgporn | Kafka / streaming |
+| `Okta` | `3743370f-1118-426e-8263-7cb405fd74c1` | svgporn | Okta IdP |
+
+Each class object in the JSON must include `id`, `name`, `icon`, and `componentType`. Use the script output to get the correct `icon` path — **do not guess it**.
+
 ### Validating a generated JSON before import
 
 Use the Zod schema directly to pre-validate without running the server:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,9 +274,112 @@ docker compose up -d          # Recreate fresh
 - Lint check passes
 - Build succeeds
 
+## Creating and Importing Threat Model JSON
+
+Gram supports exporting and importing full threat models as JSON. When an AI agent generates or modifies a threat model JSON for import, it **must** conform to the schema validated by Zod in `api/src/resources/gram/v1/models/jsonTransferSchema.ts` and the business-logic checks in `core/src/data/models/ModelTransferService.ts`. The sections below summarise everything an agent needs to know.
+
+### Top-level JSON structure
+
+```json
+{
+  "metadata": { "schemaVersion": 1, "exportedAt": "<ISO8601>", "exportedBy": "<email>" },
+  "model":     { "id": "<uuid>", "systemId": "<string|null>", "version": "<non-empty string>", "isTemplate": false, "shouldReviewActionItems": null },
+  "modelData": { "components": [...], "dataFlows": [...] },
+  "threats":   [...],
+  "controls":  [...],
+  "mitigations": [...],
+  "suggestions": { "threats": [], "controls": [] },
+  "links":     [],
+  "flows":     [...],
+  "resourceMatchings": [],
+  "review":    null
+}
+```
+
+### Component types (`modelData.components`)
+
+| `type` | Meaning |
+|--------|---------|
+| `"ee"` | External Entity (actor or external system outside trust boundary) |
+| `"proc"` | Process (internal service or application) |
+| `"ds"` | Data Store (database, file store, cache) |
+| `"tb"` | Trust Boundary (visual grouping box, no threat attachment) |
+
+Required fields per component: `id` (UUID), `x` (number), `y` (number), `type`, `name`.
+Optional: `width`, `height`, `description`, `classes`, `systems` (array of system-ID strings).
+
+### Canvas coordinate system
+
+- Component positions (`x`, `y`) are the top-left corner in canvas pixels.
+- A typical canvas layout uses 100–200 px spacing between components.
+- Trust boundary boxes use `width` and `height` to define their extent.
+- Data flow `points` arrays are flat `[x1, y1, x2, y2, ...]` canvas coordinates that define waypoints **between** the start and end components. An empty array `[]` draws a straight line.
+
+### Enum values — use exactly these strings
+
+| Field | Valid values |
+|-------|-------------|
+| `threats[].severity` | `"informative"` `"low"` `"medium"` `"high"` `"critical"` |
+| `suggestions[].status` | `"new"` `"rejected"` `"accepted"` |
+| `review.status` | `"requested"` `"approved"` `"canceled"` `"meeting-requested"` |
+| `links[].objectType` | `"model"` `"threat"` `"control"` `"system"` |
+| `modelData.components[].type` | `"ee"` `"ds"` `"proc"` `"tb"` |
+
+### Referential integrity rules (enforced by server)
+
+1. All `id` fields must be valid UUID strings.
+2. Every `dataFlow.startComponent.id` and `dataFlow.endComponent.id` must match a component `id` in `modelData.components`.
+3. Every `threats[].componentId` and `controls[].componentId` must match a component `id` **or** a data flow `id` (threats/controls can be attached to either).
+4. Every `mitigations[].threatId` must match a `threats[].id`; every `mitigations[].controlId` must match a `controls[].id`. There is **no skipping** — unresolvable mitigations throw an error.
+5. Every `flows[].dataFlowId` must match a data flow `id`; every `flows[].originComponentId` must match a component `id`. Unresolvable flows also throw an error (unlike threats/controls which are skipped with a warning).
+6. `metadata.schemaVersion` must be exactly `1`.
+
+### Size constraint
+
+The import handler enforces a **10 MB** limit on the payload (`importJson.ts`). The Express body parser allows **15 MB** (slightly higher so the handler's error message is displayed instead of a generic 413). Keep generated JSON files well under 10 MB.
+
+For large models, reduce verbose descriptions or remove the optional `aiInstructions` block from `metadata` before importing. A safe rule of thumb: descriptions truncated to 350 characters and no `aiInstructions` will keep a 40-threat / 60-control model well under the limit.
+
+### Validating a generated JSON before import
+
+Use the Zod schema directly to pre-validate without running the server:
+
+```bash
+# Install zod v3 (matches Gram's pinned version) in a temp dir
+mkdir -p /tmp/gram-validate && cd /tmp/gram-validate
+npm init -y && npm install zod@3
+
+# Then write a validate.js script that imports ModelJsonTransferPayloadSchema
+# (replicate the schema from api/src/resources/gram/v1/models/jsonTransferSchema.ts)
+node validate.js /path/to/your-model.json
+```
+
+A validation script template is kept at `/tmp/gram-validate/validate.js` from prior sessions; re-create it from the schema file if the temp directory has been cleaned.
+
+### flows array
+
+Each entry in `flows` describes one direction of a data flow from a given component's perspective:
+
+```json
+{
+  "dataFlowId": "<uuid of the dataFlow>",
+  "originComponentId": "<uuid of the component that initiates this flow direction>",
+  "summary": "Short human-readable description",
+  "attributes": {
+    "protocols": ["HTTPS"],
+    "authentication": ["OIDC"],
+    "data_type": ["Personal Information"]
+  }
+}
+```
+
+Bidirectional data flows typically have **two** entries (one per direction, with different `originComponentId`).
+
 ## Additional Resources
 
 - **Threat Modeling**: See [README.md](README.md) for feature overview
 - **Contributing**: See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - **Deployment**: See [QuickStart.md](QuickStart.md) for deployment setup
 - **Development Details**: See [Development.md](Development.md) for technical details
+- **JSON Transfer Schema**: `api/src/resources/gram/v1/models/jsonTransferSchema.ts`
+- **Import Service Logic**: `core/src/data/models/ModelTransferService.ts`

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -58,7 +58,8 @@ export async function createApp(
   app.use(metricsMiddleware);
 
   // JSON middleware to automatically parse incoming requests
-  app.use(express.json());
+  // Limit raised to 20mb to accommodate large threat model imports (default 100kb is too small)
+  app.use(express.json({ limit: "15mb" }));
   app.use(cookieParser() as unknown as express.RequestHandler);
   app.use(securityHeaders());
 

--- a/scripts/list-component-classes.py
+++ b/scripts/list-component-classes.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+list-component-classes.py — Gram component class catalog generator
+
+Reads all installed Gram plugin class files and prints every available
+component class (id, name, icon path, source plugin).  Useful for AI
+agents and developers when assigning tech-stack classes to components
+in a threat-model JSON.
+
+Usage (run from repo root):
+    python3 scripts/list-component-classes.py
+    python3 scripts/list-component-classes.py --format json
+    python3 scripts/list-component-classes.py --filter aws
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+PLUGIN_CLASS_FILES = {
+    "klarna":    "plugins/klarna/src/classes.ts",
+    "aws":       "plugins/aws/src/classes.ts",
+    "azure":     "plugins/azure/src/classes.ts",
+    "svgporn":   "plugins/svgporn/src/classes.ts",
+    "kubernetes":"plugins/kubernetes/src/classes.ts",
+    "cncf":      "plugins/cncf/src/classes.ts",
+}
+
+
+def parse_ts_classes(filepath: Path) -> list[dict]:
+    """Parse { id, name, icon, componentType } object literals from a TS file."""
+    content = filepath.read_text()
+    entries = []
+    for block in re.findall(r'\{[^{}]+\}', content, re.DOTALL):
+        id_m   = re.search(r'id:\s*["\']([^"\']+)["\']', block)
+        name_m = re.search(r'name:\s*["\']([^"\']+)["\']', block)
+        icon_m = re.search(r'icon:\s*["\']([^"\']+)["\']', block)
+        type_m = re.search(r'componentType:\s*["\']([^"\']+)["\']', block)
+        if id_m and name_m:
+            entries.append({
+                "id":            id_m.group(1),
+                "name":          name_m.group(1),
+                "icon":          icon_m.group(1) if icon_m else "",
+                "componentType": type_m.group(1) if type_m else "any",
+            })
+    return entries
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--format", choices=["table", "json"], default="table",
+                        help="Output format (default: table)")
+    parser.add_argument("--filter", metavar="TERM",
+                        help="Case-insensitive substring filter on class name")
+    parser.add_argument("--plugin", choices=list(PLUGIN_CLASS_FILES.keys()),
+                        help="Restrict to a single plugin")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).parent.parent
+    all_classes = []
+
+    plugins = {args.plugin: PLUGIN_CLASS_FILES[args.plugin]} if args.plugin else PLUGIN_CLASS_FILES
+    for plugin_name, rel_path in plugins.items():
+        fpath = repo_root / rel_path
+        if not fpath.exists():
+            print(f"WARNING: {fpath} not found — skipping", file=sys.stderr)
+            continue
+        for entry in parse_ts_classes(fpath):
+            all_classes.append({**entry, "plugin": plugin_name})
+
+    if args.filter:
+        term = args.filter.lower()
+        all_classes = [c for c in all_classes if term in c["name"].lower()]
+
+    all_classes.sort(key=lambda c: (c["plugin"], c["name"].lower()))
+
+    if args.format == "json":
+        print(json.dumps(all_classes, indent=2))
+        return
+
+    # Table output
+    col_w = {"plugin": 10, "name": 50, "id": 36, "icon": 70}
+    header = (f"{'PLUGIN':<{col_w['plugin']}}  {'NAME':<{col_w['name']}}  "
+              f"{'ID':<{col_w['id']}}  ICON")
+    sep = "-" * (len(header) + 10)
+    print(sep)
+    print(header)
+    print(sep)
+    for c in all_classes:
+        print(f"{c['plugin']:<{col_w['plugin']}}  "
+              f"{c['name']:<{col_w['name']}}  "
+              f"{c['id']:<{col_w['id']}}  "
+              f"{c['icon']}")
+    print(sep)
+    print(f"Total: {len(all_classes)} classes")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two small, independent improvements bundled in one PR — both motivated by real friction when using Gram to author and import large threat models.

### 1. Raise the `express.json()` body-parser limit from 100 KB to 15 MB (`api/src/app.ts`)

The existing import handler (`importJson.ts`) already enforces a clear 10 MB limit with a meaningful error message:

```
res.status(413).json({ error: "Import payload is too large." });
```

However, Express' default 100 KB body limit fires first, which means even moderately-sized threat model exports (for example a model with ~40 threats and ~65 controls can easily exceed 100 KB) get rejected with a generic `"Failed to import JSON"` error on the client, with no actionable detail in the logs.

Raising the parser limit to 15 MB (slightly above the handler's 10 MB guard) means the handler's explicit check fires first and users see the intended error when they exceed the real limit. Payloads below 10 MB now import cleanly.

### 2. `AGENTS.md` — comprehensive *Creating and Importing Threat Model JSON* section

Generating or editing Gram threat-model JSON requires knowledge currently scattered across:

- `api/src/resources/gram/v1/models/jsonTransferSchema.ts` (Zod schema)
- `core/src/data/models/ModelTransferService.ts` (business-logic validation)
- Individual plugin class files (tech-stack class IDs and icons)

When this knowledge isn't readily available, it's easy to produce JSON that fails import with opaque errors. The new section in `AGENTS.md` covers:

- Top-level JSON structure with all required keys
- Component types (`ee` / `proc` / `ds` / `tb`) and required fields
- Canvas coordinate system and data-flow waypoint format
- **Exact enum strings** — easy to get wrong without source inspection (severity, suggestion status, review status, link object type, component type)
- Server-side referential integrity rules (threats/controls/mitigations/flows resolution behaviour)
- 10 MB payload size constraint with a practical trimming recipe for large models
- `flows` array format (bidirectional flows use two entries with different `originComponentId`)
- How to locally pre-validate a generated JSON using Zod v3 before attempting import

### 3. `scripts/list-component-classes.py` + *Discovering and assigning component classes* section

A standalone Python script (no dependencies) that parses all plugin class TypeScript source files and prints a filterable catalog of every available class (`id`, `name`, `icon` path, source plugin). Supports:

```bash
python3 scripts/list-component-classes.py                     # table, all plugins
python3 scripts/list-component-classes.py --filter secrets    # keyword filter
python3 scripts/list-component-classes.py --plugin aws        # single plugin
python3 scripts/list-component-classes.py --format json       # machine-readable
```

Paired with a ~20-entry quick-reference table in `AGENTS.md` covering the most commonly needed classes (AWS, Azure, Google Workspace, Slack, Python, Kafka, Okta etc.) so agents and contributors can look up IDs and icon paths at a glance instead of reading raw TS source.

## Why

These changes came out of real use: while generating threat-model JSON via an AI agent I hit three stumbling blocks in quick succession:

1. The 100 KB body limit rejected a moderately-sized model with an opaque error.
2. The agent repeatedly produced invalid enum values and flow references because the rules were only implicit in source code.
3. The agent had no easy way to discover which `classes` to tag components with.

The script and quick-ref table dramatically improve the first-try success rate of agent-generated threat models, and the body-limit raise unblocks anyone trying to import a realistic model.

## Test plan

**Body limit**

- [ ] Import a threat model JSON between 100 KB and 10 MB and confirm success (previously failed with a generic error)
- [ ] Import a JSON larger than 10 MB and confirm the handler returns `"Import payload is too large."` (not a generic 413 with no body)

**AGENTS.md guide**

- [ ] Review enum tables against `core/src/data/threats/Threat.ts`, `reviews/Review.ts`, `suggestions/Suggestion.ts`, `links/Link.ts`
- [ ] Review referential-integrity rules against `core/src/data/models/ModelTransferService.ts` `validatePayload()`
- [ ] Validate a sample exported model JSON using the described Zod v3 local-validation approach

**Component class catalog script**

- [ ] `python3 scripts/list-component-classes.py` prints a table covering all plugins in `plugins/`
- [ ] `--filter secrets` returns only matching classes
- [ ] `--plugin aws` returns only AWS classes
- [ ] `--format json` emits valid JSON
- [ ] Cross-check 3–5 IDs from the `AGENTS.md` quick-reference table against the actual plugin source files

## Changes summary

- `api/src/app.ts` — one line: `express.json()` → `express.json({ limit: "15mb" })`
- `AGENTS.md` — documentation only (+ ~150 lines)
- `scripts/list-component-classes.py` — new standalone script (no production code path)

No runtime dependencies added, no behavioural changes outside the import endpoint.