### PR TITLE
feat(api): add admin action items list and export endpoints

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -18,6 +18,7 @@ import errorHandler from "./middlewares/errorHandler.js";
 import loggerMw from "./middlewares/logger.js";
 import { securityHeaders } from "./middlewares/securityHeaders.js";
 import { actionItemRouter } from "./resources/gram/v1/action-items/router.js";
+import { adminActionItemsRouter } from "./resources/gram/v1/admin/action-items/router.js";
 import crash from "./resources/gram/v1/admin/crash.js";
 import { retryReviewApproval } from "./resources/gram/v1/admin/retryReviewApproval.js";
 import setRoles from "./resources/gram/v1/admin/setRoles.js";
@@ -166,6 +167,11 @@ export async function createApp(
     "/admin/retry_review_approval",
     authz.is(Role.Admin),
     retryReviewApproval(dal)
+  );
+  authenticatedRoutes.use(
+    "/admin/action-items",
+    authz.is(Role.Admin),
+    adminActionItemsRouter(dal)
   );
 
   app.use("/api/v1", unauthenticatedRoutes);

--- a/api/src/resources/gram/v1/admin/action-items/admin-action-items.spec.ts
+++ b/api/src/resources/gram/v1/admin/action-items/admin-action-items.spec.ts
@@ -1,0 +1,224 @@
+import { jest } from "@jest/globals";
+import { DataAccessLayer } from "@gram/core/dist/data/dal.js";
+import { LinkObjectType } from "@gram/core/dist/data/links/Link.js";
+import Model from "@gram/core/dist/data/models/Model.js";
+import Threat, { ThreatSeverity } from "@gram/core/dist/data/threats/Threat.js";
+import { randomUUID } from "crypto";
+import request from "supertest";
+import { createTestApp } from "../../../../../test-util/app.js";
+import { sampleOwnedSystem } from "../../../../../test-util/sampleOwnedSystem.js";
+import {
+  sampleAdminToken,
+  sampleUserToken,
+} from "../../../../../test-util/sampleTokens.js";
+import { sampleUser } from "../../../../../test-util/sampleUser.js";
+
+const adminToken = await sampleAdminToken();
+const userToken = await sampleUserToken();
+
+const EXPORTER = "dummy"; // registered by the test config (DummyActionItemExporter)
+
+describe("admin action-items endpoints", () => {
+  let app: any;
+  let dal: DataAccessLayer;
+  let modelId: string;
+
+  beforeAll(async () => {
+    ({ app, dal } = await createTestApp());
+  });
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    const model = new Model(sampleOwnedSystem.id, "v", sampleUser.sub);
+    model.data = { components: [], dataFlows: [] };
+    modelId = await dal.modelService.create(model);
+  });
+
+  async function actionItem(): Promise<string> {
+    const t = new Threat("t", "d", modelId, randomUUID(), sampleUser.sub);
+    const id = await dal.threatService.create(t);
+    await dal.threatService.update(modelId, id, {
+      isActionItem: true,
+      severity: ThreatSeverity.High,
+    });
+    return id;
+  }
+
+  describe("GET /api/v1/admin/action-items", () => {
+    it("401 unauthenticated", async () => {
+      const res = await request(app).get("/api/v1/admin/action-items");
+      expect(res.status).toBe(401);
+    });
+
+    it("403 for non-admin", async () => {
+      const res = await request(app)
+        .get("/api/v1/admin/action-items")
+        .set("Authorization", userToken);
+      expect(res.status).toBe(403);
+    });
+
+    it("200 for admin with envelope", async () => {
+      await actionItem();
+      const res = await request(app)
+        .get("/api/v1/admin/action-items")
+        .set("Authorization", adminToken);
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("total");
+      expect(res.body).toHaveProperty("limit", 50);
+      expect(res.body).toHaveProperty("offset", 0);
+      expect(Array.isArray(res.body.actionItems)).toBe(true);
+    });
+
+    it("400 for unknown exporterKey", async () => {
+      const res = await request(app)
+        .get("/api/v1/admin/action-items?exporterKey=nope")
+        .set("Authorization", adminToken);
+      expect(res.status).toBe(400);
+    });
+
+    it("filters by severity server-side", async () => {
+      const highId = await actionItem(); // actionItem() sets High
+      const lowId = await actionItem();
+      await dal.threatService.update(modelId, lowId, {
+        severity: ThreatSeverity.Low,
+      });
+
+      const res = await request(app)
+        .get(
+          "/api/v1/admin/action-items?severity=medium&severity=high&severity=critical"
+        )
+        .set("Authorization", adminToken);
+
+      expect(res.status).toBe(200);
+      const ids = res.body.actionItems.map((a: any) => a.id);
+      expect(ids).toContain(highId);
+      expect(ids).not.toContain(lowId);
+    });
+
+    it("400 for invalid severity", async () => {
+      const res = await request(app)
+        .get("/api/v1/admin/action-items?severity=bogus")
+        .set("Authorization", adminToken);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("POST /api/v1/admin/action-items/export", () => {
+    const post = (body: any, token = adminToken) =>
+      request(app)
+        .post("/api/v1/admin/action-items/export")
+        .set("Authorization", token)
+        .send(body);
+
+    it("401 unauthenticated", async () => {
+      const res = await request(app)
+        .post("/api/v1/admin/action-items/export")
+        .send({ exporterKey: EXPORTER, threatIds: [randomUUID()] });
+      expect(res.status).toBe(401);
+    });
+
+    it("403 for non-admin", async () => {
+      const res = await post(
+        { exporterKey: EXPORTER, threatIds: [randomUUID()] },
+        userToken
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("400 for unknown exporterKey", async () => {
+      const res = await post({
+        exporterKey: "nope",
+        threatIds: [randomUUID()],
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("400 for empty batch", async () => {
+      const res = await post({ exporterKey: EXPORTER, threatIds: [] });
+      expect(res.status).toBe(400);
+    });
+
+    it("400 for oversized batch", async () => {
+      const threatIds = Array.from({ length: 101 }, () => randomUUID());
+      const res = await post({ exporterKey: EXPORTER, threatIds });
+      expect(res.status).toBe(400);
+    });
+
+    it("partitions notFound / notAnActionItem and keeps the summary invariant", async () => {
+      const ai = await actionItem();
+      const plain = await dal.threatService.create(
+        new Threat("p", "d", modelId, randomUUID(), sampleUser.sub)
+      );
+      const missing = randomUUID();
+
+      const res = await post({
+        exporterKey: EXPORTER,
+        threatIds: [ai, plain, missing, ai], // duplicate ai → deduped
+      });
+
+      expect(res.status).toBe(200);
+      const { requested, summary, results } = res.body;
+      expect(requested).toBe(3); // deduped
+      const sum = Object.values(summary).reduce(
+        (a: number, b: any) => a + b,
+        0
+      );
+      expect(sum).toBe(requested);
+      expect(results.length).toBe(requested);
+      const byId = Object.fromEntries(
+        results.map((r: any) => [r.threatId, r.outcome])
+      );
+      expect(byId[missing]).toBe("notFound");
+      expect(byId[plain]).toBe("notAnActionItem");
+      // dummy exporter is a no-op → eligible item has no link → notExported
+      expect(byId[ai]).toBe("notExported");
+    });
+
+    it("classifies a newly linked item as exported (link-diff after)", async () => {
+      const ai = await actionItem();
+      jest
+        .spyOn(dal.actionItemHandler, "export")
+        .mockImplementation(async (key, items) => {
+          for (const t of items) {
+            await dal.linkService.insertLink(
+              LinkObjectType.Threat,
+              t.id!,
+              "l",
+              "https://ticket",
+              "",
+              key
+            );
+          }
+        });
+
+      const res = await post({ exporterKey: EXPORTER, threatIds: [ai] });
+      expect(res.status).toBe(200);
+      expect(res.body.summary.exported).toBe(1);
+      expect(res.body.results[0]).toMatchObject({
+        threatId: ai,
+        outcome: "exported",
+        link: "https://ticket",
+      });
+    });
+
+    it("classifies a pre-linked item as alreadyExported (link-diff before)", async () => {
+      const ai = await actionItem();
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        ai,
+        "l",
+        "https://existing",
+        "",
+        EXPORTER
+      );
+      jest
+        .spyOn(dal.actionItemHandler, "export")
+        .mockImplementation(async () => {});
+
+      const res = await post({ exporterKey: EXPORTER, threatIds: [ai] });
+      expect(res.status).toBe(200);
+      expect(res.body.summary.alreadyExported).toBe(1);
+      expect(res.body.results[0].outcome).toBe("alreadyExported");
+    });
+  });
+});

--- a/api/src/resources/gram/v1/admin/action-items/export.ts
+++ b/api/src/resources/gram/v1/admin/action-items/export.ts
@@ -1,0 +1,121 @@
+import { Request, Response } from "express";
+import { DataAccessLayer } from "@gram/core/dist/data/dal.js";
+import { LinkObjectType } from "@gram/core/dist/data/links/Link.js";
+import { z } from "zod";
+
+const MAX_BATCH = 100;
+
+export type ExportOutcome =
+  | "exported"
+  | "alreadyExported"
+  | "notExported"
+  | "notFound"
+  | "notAnActionItem";
+
+export interface ExportResult {
+  threatId: string;
+  outcome: ExportOutcome;
+  link?: string;
+}
+
+const BodySchema = z.object({
+  exporterKey: z.string(),
+  threatIds: z.array(z.string()).min(1).max(MAX_BATCH),
+});
+
+const emptySummary = (): Record<ExportOutcome, number> => ({
+  exported: 0,
+  alreadyExported: 0,
+  notExported: 0,
+  notFound: 0,
+  notAnActionItem: 0,
+});
+
+/**
+ * POST /api/v1/admin/action-items/export
+ * Re-export an explicit list of action items to one exporter, synchronously.
+ * Per-threat outcome is derived by link-diff (exporter links before/after),
+ * never from the exporter's void return. Admin role enforced at router mount.
+ */
+export function exportAdminActionItems(dal: DataAccessLayer) {
+  return async (req: Request, res: Response) => {
+    const parsed = BodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.flatten() });
+      return;
+    }
+    const { exporterKey } = parsed.data;
+
+    const registeredKeys = dal.actionItemHandler.exporters.map((e) => e.key);
+    if (!registeredKeys.includes(exporterKey)) {
+      res.status(400).json({ error: `Unknown exporterKey: ${exporterKey}` });
+      return;
+    }
+
+    // Dedup requested ids; the summary partitions exactly this set.
+    const requestedIds = [...new Set(parsed.data.threatIds)];
+
+    // Partition: notFound (absent/deleted) vs notAnActionItem vs eligible.
+    const threats = await dal.threatService.listByIds(requestedIds);
+    const byId = new Map(threats.map((t) => [t.id!, t]));
+
+    const results: ExportResult[] = [];
+    const eligible = [];
+    for (const id of requestedIds) {
+      const threat = byId.get(id);
+      if (!threat) {
+        results.push({ threatId: id, outcome: "notFound" });
+      } else if (!threat.isActionItem) {
+        results.push({ threatId: id, outcome: "notAnActionItem" });
+      } else {
+        eligible.push(threat);
+      }
+    }
+
+    const eligibleIds = eligible.map((t) => t.id!);
+
+    // BEFORE snapshot — which eligible threats already had an exporter link.
+    const before = await dal.linkService.listLinksForObjects(
+      LinkObjectType.Threat,
+      eligibleIds,
+      exporterKey
+    );
+    const hadLinkBefore = new Set(before.map((l) => l.objectId));
+
+    if (eligible.length > 0) {
+      await dal.actionItemHandler.export(exporterKey, eligible);
+    }
+
+    // AFTER snapshot — link url per eligible threat (if any).
+    const after = await dal.linkService.listLinksForObjects(
+      LinkObjectType.Threat,
+      eligibleIds,
+      exporterKey
+    );
+    const linkAfter = new Map(after.map((l) => [l.objectId, l.url]));
+
+    for (const threat of eligible) {
+      const id = threat.id!;
+      const url = linkAfter.get(id);
+      if (hadLinkBefore.has(id)) {
+        results.push({ threatId: id, outcome: "alreadyExported", link: url });
+      } else if (url !== undefined) {
+        results.push({ threatId: id, outcome: "exported", link: url });
+      } else {
+        results.push({ threatId: id, outcome: "notExported" });
+      }
+    }
+
+    const summary = emptySummary();
+    for (const r of results) {
+      summary[r.outcome] += 1;
+    }
+
+    res.json({
+      exporterKey,
+      requested: requestedIds.length,
+      summary,
+      results,
+    });
+  };
+}

--- a/api/src/resources/gram/v1/admin/action-items/list.ts
+++ b/api/src/resources/gram/v1/admin/action-items/list.ts
@@ -1,0 +1,100 @@
+import { Request, Response } from "express";
+import { DataAccessLayer } from "@gram/core/dist/data/dal.js";
+import {
+  ActionItemFilter,
+  ExportStatusFilter,
+} from "@gram/core/dist/data/threats/ThreatDataService.js";
+import { ThreatSeverity } from "@gram/core/dist/data/threats/Threat.js";
+import { z } from "zod";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 500;
+
+/** Accept an ISO 8601 date or date-time string (Postgres timestamptz casts both). */
+const isoDate = z
+  .string()
+  .refine((v) => !Number.isNaN(Date.parse(v)), "must be an ISO 8601 date");
+
+const severityEnum = z.nativeEnum(ThreatSeverity);
+
+const QuerySchema = z.object({
+  systemId: z.union([z.string(), z.array(z.string())]).optional(),
+  createdFrom: isoDate.optional(),
+  createdTo: isoDate.optional(),
+  reviewApprovedFrom: isoDate.optional(),
+  reviewApprovedTo: isoDate.optional(),
+  severity: z.union([severityEnum, z.array(severityEnum)]).optional(),
+  exporterKey: z.string().optional(),
+  exportStatus: z.enum(["exported", "not-exported"]).optional(),
+  limit: z.coerce.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+/**
+ * GET /api/v1/admin/action-items
+ * Admin-only filtered fetch of action items across all systems/models.
+ * Admin role is enforced at the router mount; this handler is a thin wrapper.
+ */
+export function listAdminActionItems(dal: DataAccessLayer) {
+  return async (req: Request, res: Response) => {
+    const parsed = QuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.flatten() });
+      return;
+    }
+    const q = parsed.data;
+
+    const registeredKeys = dal.actionItemHandler.exporters.map((e) => e.key);
+    if (q.exporterKey && !registeredKeys.includes(q.exporterKey)) {
+      res.status(400).json({ error: `Unknown exporterKey: ${q.exporterKey}` });
+      return;
+    }
+
+    const systemIds =
+      q.systemId === undefined
+        ? undefined
+        : Array.isArray(q.systemId)
+        ? q.systemId
+        : [q.systemId];
+
+    const severities =
+      q.severity === undefined
+        ? undefined
+        : Array.isArray(q.severity)
+        ? q.severity
+        : [q.severity];
+
+    // Caller resolves the export scope; the service stays agnostic of the registry.
+    const exporterScope = q.exporterKey ? [q.exporterKey] : registeredKeys;
+
+    const filter: ActionItemFilter = {
+      systemIds,
+      createdFrom: q.createdFrom,
+      createdTo: q.createdTo,
+      reviewApprovedFrom: q.reviewApprovedFrom,
+      reviewApprovedTo: q.reviewApprovedTo,
+      severities,
+      exportStatus: q.exportStatus as ExportStatusFilter | undefined,
+      exporterScope,
+      limit: q.limit,
+      offset: q.offset,
+    };
+
+    const { total, items } = await dal.threatService.listActionItemsFiltered(
+      filter
+    );
+
+    res.json({
+      total,
+      limit: q.limit,
+      offset: q.offset,
+      actionItems: items.map((item) => ({
+        ...item.threat.toJSON(),
+        systemId: item.systemId,
+        reviewApprovedAt: item.reviewApprovedAt,
+        exported: item.exported,
+        exportLinks: item.exportLinks,
+      })),
+    });
+  };
+}

--- a/api/src/resources/gram/v1/admin/action-items/router.ts
+++ b/api/src/resources/gram/v1/admin/action-items/router.ts
@@ -1,0 +1,16 @@
+import { DataAccessLayer } from "@gram/core/dist/data/dal.js";
+import express from "express";
+
+import { exportAdminActionItems } from "./export.js";
+import { listAdminActionItems } from "./list.js";
+
+/**
+ * Admin-only action item tooling. Mounted under /admin/action-items behind an
+ * admin-role gate in app.ts.
+ */
+export function adminActionItemsRouter(dal: DataAccessLayer): express.Router {
+  const router = express.Router({ mergeParams: true });
+  router.get("/", listAdminActionItems(dal));
+  router.post("/export", exportAdminActionItems(dal));
+  return router;
+}

--- a/core/src/data/links/LinkDataService.ts
+++ b/core/src/data/links/LinkDataService.ts
@@ -62,6 +62,46 @@ export class LinkDataService extends EventEmitter {
     );
   }
 
+  /**
+   * Batched link lookup over many objects in a single query, optionally scoped to
+   * one created_by. Used for Endpoint 2's before/after export snapshots to avoid
+   * N round-trips. Returns [] for empty input.
+   */
+  async listLinksForObjects(
+    objectType: LinkObjectType,
+    objectIds: LinkObjectId[],
+    createdBy?: string
+  ): Promise<Link[]> {
+    if (objectIds.length === 0) {
+      return [];
+    }
+    const params: any[] = [objectType, objectIds];
+    let query = `
+      SELECT * FROM links
+      WHERE object_type = $1 AND object_id = ANY($2::varchar[])
+    `;
+    if (createdBy !== undefined) {
+      params.push(createdBy);
+      query += ` AND created_by = $3`;
+    }
+
+    const res = await this.pool.query(query, params);
+    return res.rows.map(
+      (row) =>
+        new Link(
+          row.id,
+          row.object_type,
+          row.object_id,
+          row.label,
+          row.url,
+          row.icon,
+          row.created_by,
+          row.created_at,
+          row.updated_at
+        )
+    );
+  }
+
   async insertLink(
     objectType: LinkObjectType,
     objectId: LinkObjectId,

--- a/core/src/data/threats/AdminActionItems.spec.ts
+++ b/core/src/data/threats/AdminActionItems.spec.ts
@@ -1,0 +1,280 @@
+import { randomUUID } from "crypto";
+import { DataAccessLayer } from "../dal.js";
+import { LinkObjectType } from "../links/Link.js";
+import Model from "../models/Model.js";
+import { createPostgresPool } from "../postgres.js";
+import { _deleteAllTheThings } from "../utils.js";
+import Threat, { ThreatSeverity } from "./Threat.js";
+import { ThreatDataService } from "./ThreatDataService.js";
+
+describe("Admin action item queries", () => {
+  let data: ThreatDataService;
+  let dal: DataAccessLayer;
+
+  beforeAll(async () => {
+    const pool = await createPostgresPool();
+    dal = new DataAccessLayer(pool);
+    data = dal.threatService;
+  });
+
+  beforeEach(async () => {
+    await _deleteAllTheThings(dal);
+  });
+
+  afterAll(async () => {
+    await dal.pool.end();
+  });
+
+  async function createModel(systemId: string): Promise<string> {
+    const model = new Model(systemId, "v", "root");
+    model.data = { components: [], dataFlows: [] };
+    return await dal.modelService.create(model);
+  }
+
+  async function createActionItem(
+    modelId: string,
+    isActionItem = true
+  ): Promise<Threat> {
+    const t = new Threat("t", "d", modelId, randomUUID(), "creator");
+    t.id = await data.create(t);
+    if (isActionItem) {
+      await data.update(modelId, t.id!, {
+        isActionItem: true,
+        severity: ThreatSeverity.High,
+      });
+    }
+    return t;
+  }
+
+  async function approveReview(modelId: string, approvedAt: string) {
+    await dal.pool.query(
+      `INSERT INTO reviews (model_id, status, approved_at) VALUES ($1, 'approved', $2)`,
+      [modelId, approvedAt]
+    );
+  }
+
+  const baseFilter = {
+    exporterScope: ["wikibase"],
+    limit: 50,
+    offset: 0,
+  };
+
+  describe("listByIds", () => {
+    it("returns [] for empty input", async () => {
+      expect(await data.listByIds([])).toEqual([]);
+    });
+
+    it("returns non-deleted threats by id with is_action_item", async () => {
+      const modelId = await createModel("sys-a");
+      const ai = await createActionItem(modelId, true);
+      const plain = await createActionItem(modelId, false);
+
+      const rows = await data.listByIds([ai.id!, plain.id!]);
+      const byId = new Map(rows.map((r) => [r.id, r]));
+      expect(rows.length).toBe(2);
+      expect(byId.get(ai.id!)?.isActionItem).toBe(true);
+      expect(byId.get(plain.id!)?.isActionItem).toBe(false);
+    });
+
+    it("excludes deleted threats", async () => {
+      const modelId = await createModel("sys-a");
+      const ai = await createActionItem(modelId);
+      await data.delete(modelId, ai.id!);
+      expect(await data.listByIds([ai.id!])).toEqual([]);
+    });
+  });
+
+  describe("listActionItemsFiltered", () => {
+    it("returns only action items, with total", async () => {
+      const modelId = await createModel("sys-a");
+      await createActionItem(modelId, true);
+      await createActionItem(modelId, false); // regular threat, excluded
+
+      const { total, items } = await data.listActionItemsFiltered(baseFilter);
+      expect(total).toBe(1);
+      expect(items.length).toBe(1);
+      expect(items[0].systemId).toBe("sys-a");
+      expect(items[0].threat.isActionItem).toBe(true);
+    });
+
+    it("filters by systemId", async () => {
+      const a = await createModel("sys-a");
+      const b = await createModel("sys-b");
+      await createActionItem(a);
+      await createActionItem(b);
+
+      const { items } = await data.listActionItemsFiltered({
+        ...baseFilter,
+        systemIds: ["sys-a"],
+      });
+      expect(items.length).toBe(1);
+      expect(items[0].systemId).toBe("sys-a");
+    });
+
+    it("marks exported when an exporter link exists, with link urls", async () => {
+      const modelId = await createModel("sys-a");
+      const ai = await createActionItem(modelId);
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        ai.id!,
+        "label",
+        "https://wb/Q1",
+        "",
+        "wikibase"
+      );
+
+      const { items } = await data.listActionItemsFiltered(baseFilter);
+      expect(items[0].exported).toBe(true);
+      expect(items[0].exportLinks).toHaveLength(1);
+      expect(items[0].exportLinks[0].url).toBe("https://wb/Q1");
+    });
+
+    it("does NOT count a user-added link as exported", async () => {
+      const modelId = await createModel("sys-a");
+      const ai = await createActionItem(modelId);
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        ai.id!,
+        "label",
+        "https://ref",
+        "",
+        "alice@klarna.com" // user sub, not an exporter key
+      );
+
+      const { items } = await data.listActionItemsFiltered(baseFilter);
+      expect(items[0].exported).toBe(false);
+      expect(items[0].exportLinks).toEqual([]);
+    });
+
+    it("does not multiply rows when a threat has multiple exporter links", async () => {
+      const modelId = await createModel("sys-a");
+      const ai = await createActionItem(modelId);
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        ai.id!,
+        "l1",
+        "https://wb/Q1",
+        "",
+        "wikibase"
+      );
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        ai.id!,
+        "l2",
+        "https://wb/Q2",
+        "",
+        "wikibase"
+      );
+
+      const { total, items } = await data.listActionItemsFiltered(baseFilter);
+      expect(total).toBe(1);
+      expect(items.length).toBe(1);
+      expect(items[0].exportLinks).toHaveLength(2);
+    });
+
+    it("filters by exportStatus exported / not-exported", async () => {
+      const modelId = await createModel("sys-a");
+      const exported = await createActionItem(modelId);
+      await createActionItem(modelId); // not exported
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        exported.id!,
+        "l",
+        "https://wb/Q1",
+        "",
+        "wikibase"
+      );
+
+      const onlyExported = await data.listActionItemsFiltered({
+        ...baseFilter,
+        exportStatus: "exported",
+      });
+      expect(onlyExported.items.map((i) => i.threat.id)).toEqual([exported.id]);
+
+      const onlyMissing = await data.listActionItemsFiltered({
+        ...baseFilter,
+        exportStatus: "not-exported",
+      });
+      expect(onlyMissing.items.map((i) => i.threat.id)).not.toContain(
+        exported.id
+      );
+      expect(onlyMissing.items).toHaveLength(1);
+    });
+
+    it("filters by severity (one or many)", async () => {
+      const modelId = await createModel("sys-a");
+      const high = await createActionItem(modelId); // createActionItem sets High
+      const low = await createActionItem(modelId);
+      await data.update(modelId, low.id!, { severity: ThreatSeverity.Low });
+
+      const { items } = await data.listActionItemsFiltered({
+        ...baseFilter,
+        severities: [
+          ThreatSeverity.Medium,
+          ThreatSeverity.High,
+          ThreatSeverity.Critical,
+        ],
+      });
+      expect(items.map((i) => i.threat.id)).toEqual([high.id]);
+    });
+
+    it("reviewApproved range excludes items whose model has no approved review", async () => {
+      const withReview = await createModel("sys-a");
+      const without = await createModel("sys-b");
+      const aiWith = await createActionItem(withReview);
+      await createActionItem(without);
+      await approveReview(withReview, "2026-06-10T00:00:00Z");
+
+      const { items } = await data.listActionItemsFiltered({
+        ...baseFilter,
+        reviewApprovedFrom: "2026-06-01T00:00:00Z",
+        reviewApprovedTo: "2026-06-30T00:00:00Z",
+      });
+      expect(items.map((i) => i.threat.id)).toEqual([aiWith.id]);
+      expect(items[0].reviewApprovedAt).toBeGreaterThan(0);
+    });
+  });
+
+  describe("listLinksForObjects", () => {
+    it("returns [] for empty input", async () => {
+      expect(
+        await dal.linkService.listLinksForObjects(LinkObjectType.Threat, [])
+      ).toEqual([]);
+    });
+
+    it("batches links across objects and scopes by createdBy", async () => {
+      const modelId = await createModel("sys-a");
+      const a = await createActionItem(modelId);
+      const b = await createActionItem(modelId);
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        a.id!,
+        "l",
+        "url-a",
+        "",
+        "wikibase"
+      );
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        b.id!,
+        "l",
+        "url-b",
+        "",
+        "alice@klarna.com"
+      );
+
+      const all = await dal.linkService.listLinksForObjects(
+        LinkObjectType.Threat,
+        [a.id!, b.id!]
+      );
+      expect(all.length).toBe(2);
+
+      const scoped = await dal.linkService.listLinksForObjects(
+        LinkObjectType.Threat,
+        [a.id!, b.id!],
+        "wikibase"
+      );
+      expect(scoped.map((l) => l.objectId)).toEqual([a.id]);
+    });
+  });
+});

--- a/core/src/data/threats/ThreatDataService.ts
+++ b/core/src/data/threats/ThreatDataService.ts
@@ -30,6 +30,42 @@ export function convertToThreat(row: any): Threat {
   return threat;
 }
 
+export type ExportStatusFilter = "exported" | "not-exported";
+
+/**
+ * Filter for the admin cross-system action item query.
+ * `exporterScope` is resolved by the caller (route handler): `[exporterKey]` when
+ * a specific exporter is requested, otherwise the full set of registered exporter
+ * keys. The same scope drives both the export-status filter and the `exported`
+ * flag / `exportLinks` returned per row.
+ */
+export interface ActionItemFilter {
+  systemIds?: string[];
+  createdFrom?: string; // ISO 8601 — compared against the timestamptz column
+  createdTo?: string;
+  reviewApprovedFrom?: string;
+  reviewApprovedTo?: string;
+  severities?: ThreatSeverity[];
+  exportStatus?: ExportStatusFilter;
+  exporterScope: string[];
+  limit: number;
+  offset: number;
+}
+
+export interface ActionItemExportLink {
+  url: string;
+  createdBy: string;
+  createdAt: number; // ms
+}
+
+export interface AdminActionItem {
+  threat: Threat;
+  systemId: string | null;
+  reviewApprovedAt: number | null; // ms
+  exported: boolean; // scoped to ActionItemFilter.exporterScope
+  exportLinks: ActionItemExportLink[];
+}
+
 export class ThreatDataService extends EventEmitter {
   constructor(private dal: DataAccessLayer) {
     super();
@@ -163,6 +199,131 @@ export class ThreatDataService extends EventEmitter {
     }
 
     return res.rows.map((record) => convertToThreat(record));
+  }
+
+  /**
+   * Hydrate threats by id, for any is_action_item value (the caller partitions).
+   * Single round-trip; returns only non-deleted threats. Returns [] for empty input.
+   */
+  async listByIds(ids: string[]): Promise<Threat[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+    const query = `
+      SELECT
+        id,
+        title,
+        description,
+        model_id,
+        component_id,
+        created_by,
+        extract(epoch from created_at) as created_at,
+        extract(epoch from updated_at) as updated_at,
+        suggestion_id,
+        is_action_item,
+        severity
+      FROM threats
+      WHERE id = ANY($1::uuid[])
+      AND deleted_at IS NULL
+      ORDER BY created_at DESC
+    `;
+    const res = await this.pool.query(query, [ids]);
+    return res.rows.map((record) => convertToThreat(record));
+  }
+
+  /**
+   * Admin cross-system action item query (Endpoint 1). Pure data query over
+   * threats / models / reviews / links — applies no exporter skip logic.
+   * "exported" = the threat has a links row whose created_by is in
+   * filter.exporterScope (exporter-created links only; user links don't count).
+   */
+  async listActionItemsFiltered(
+    filter: ActionItemFilter
+  ): Promise<{ total: number; items: AdminActionItem[] }> {
+    const params: any[] = [
+      filter.exporterScope, // $1 — used in the LATERAL
+      filter.systemIds ?? null, // $2
+      filter.createdFrom ?? null, // $3
+      filter.createdTo ?? null, // $4
+      filter.reviewApprovedFrom ?? null, // $5
+      filter.reviewApprovedTo ?? null, // $6
+      filter.exportStatus ?? null, // $7
+      filter.limit, // $8
+      filter.offset, // $9
+      filter.severities ?? null, // $10
+    ];
+
+    const query = `
+      SELECT
+        t.id,
+        t.title,
+        t.description,
+        t.model_id,
+        t.component_id,
+        t.created_by,
+        t.suggestion_id,
+        extract(epoch from t.created_at) as created_at,
+        extract(epoch from t.updated_at) as updated_at,
+        t.is_action_item,
+        t.severity,
+        m.system_id,
+        extract(epoch from r.approved_at) as review_approved_at,
+        COALESCE(l.exported, false) as exported,
+        COALESCE(l.links, '[]'::json) as export_links,
+        COUNT(*) OVER() as total
+      FROM threats t
+      JOIN models m ON m.id = t.model_id
+      LEFT JOIN reviews r ON r.model_id = t.model_id
+      LEFT JOIN LATERAL (
+        SELECT
+          count(*) > 0 as exported,
+          json_agg(json_build_object(
+            'url', url,
+            'createdBy', created_by,
+            'createdAt', extract(epoch from created_at)
+          )) as links
+        FROM links
+        WHERE object_type = 'threat'
+          AND object_id = t.id::text
+          AND created_by = ANY($1::varchar[])
+      ) l ON true
+      WHERE t.is_action_item = true
+        AND t.deleted_at IS NULL
+        AND ($2::varchar[] IS NULL OR m.system_id = ANY($2::varchar[]))
+        AND ($3::timestamptz IS NULL OR t.created_at >= $3::timestamptz)
+        AND ($4::timestamptz IS NULL OR t.created_at <= $4::timestamptz)
+        AND ($5::timestamptz IS NULL OR r.approved_at >= $5::timestamptz)
+        AND ($6::timestamptz IS NULL OR r.approved_at <= $6::timestamptz)
+        AND ($10::varchar[] IS NULL OR t.severity = ANY($10::varchar[]))
+        AND ($7::text IS NULL
+          OR ($7 = 'exported' AND l.exported)
+          OR ($7 = 'not-exported' AND NOT l.exported))
+      ORDER BY t.created_at DESC
+      LIMIT $8::int OFFSET $9::int
+    `;
+
+    const res = await this.pool.query(query, params);
+
+    const total = res.rows.length > 0 ? parseInt(res.rows[0].total, 10) : 0;
+    const items: AdminActionItem[] = res.rows.map((row) => ({
+      threat: convertToThreat(row),
+      systemId: row.system_id ?? null,
+      reviewApprovedAt:
+        row.review_approved_at != null
+          ? Math.round(Number(row.review_approved_at) * 1000)
+          : null,
+      exported: row.exported ?? false,
+      exportLinks: (row.export_links ?? []).map((link: any) => ({
+        url: link.url,
+        createdBy: link.createdBy,
+        createdAt:
+          link.createdAt != null
+            ? Math.round(Number(link.createdAt) * 1000)
+            : 0,
+      })),
+    }));
+
+    return { total, items };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add admin API endpoints to list and export action items across threat models
- Extend `ThreatDataService` and `LinkDataService` with query support for admin action-item fetch
- Include API and core integration tests

## Test plan
- [ ] `npm -w @gram/api test -- api/src/resources/gram/v1/admin/action-items/admin-action-items.spec.ts`
- [ ] `npm -w @gram/core test -- core/src/data/threats/AdminActionItems.spec.ts`
- [ ] Verify list and export endpoints as admin user locally