### PR TITLE
feat(api): filter admin action items by export domain instead of exporter key

### DIFF
--- a/api/src/resources/gram/v1/admin/action-items/admin-action-items.spec.ts
+++ b/api/src/resources/gram/v1/admin/action-items/admin-action-items.spec.ts
@@ -69,9 +69,104 @@ describe("admin action-items endpoints", () => {
       expect(Array.isArray(res.body.actionItems)).toBe(true);
     });
 
-    it("400 for unknown exporterKey", async () => {
+    it("counts a user-recorded link as exported", async () => {
+      const id = await actionItem();
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        id,
+        "l",
+        "https://jira.com/browse/ABC-1",
+        "",
+        sampleUser.sub // user identity, not an exporter key
+      );
+
       const res = await request(app)
-        .get("/api/v1/admin/action-items?exporterKey=nope")
+        .get("/api/v1/admin/action-items?exportStatus=exported")
+        .set("Authorization", adminToken);
+
+      expect(res.status).toBe(200);
+      const item = res.body.actionItems.find((a: any) => a.id === id);
+      expect(item).toBeDefined();
+      expect(item.exported).toBe(true);
+    });
+
+    it("filters by exportDomain (true host match)", async () => {
+      const matchId = await actionItem();
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        matchId,
+        "l",
+        "https://team.jira.com/browse/ABC-1",
+        "",
+        sampleUser.sub
+      );
+      const otherId = await actionItem();
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        otherId,
+        "l",
+        "https://notjira.com/x",
+        "",
+        sampleUser.sub
+      );
+
+      const res = await request(app)
+        .get(
+          "/api/v1/admin/action-items?exportDomain=jira.com&exportStatus=exported"
+        )
+        .set("Authorization", adminToken);
+
+      expect(res.status).toBe(200);
+      const ids = res.body.actionItems.map((a: any) => a.id);
+      expect(ids).toContain(matchId);
+      expect(ids).not.toContain(otherId);
+    });
+
+    it("accepts multiple exportDomain values (matches ANY)", async () => {
+      const jiraId = await actionItem();
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        jiraId,
+        "l",
+        "https://jira.com/browse/ABC-1",
+        "",
+        sampleUser.sub
+      );
+      const githubId = await actionItem();
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        githubId,
+        "l",
+        "https://github.com/x",
+        "",
+        sampleUser.sub
+      );
+      const otherId = await actionItem();
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        otherId,
+        "l",
+        "https://example.com/x",
+        "",
+        sampleUser.sub
+      );
+
+      const res = await request(app)
+        .get(
+          "/api/v1/admin/action-items?exportDomain=jira.com&exportDomain=github.com&exportStatus=exported"
+        )
+        .set("Authorization", adminToken);
+
+      expect(res.status).toBe(200);
+      const ids = res.body.actionItems.map((a: any) => a.id);
+      expect(ids).toContain(jiraId);
+      expect(ids).toContain(githubId);
+      expect(ids).not.toContain(otherId);
+    });
+
+    it("400 for empty exportDomain", async () => {
+      const res = await request(app)
+        .get("/api/v1/admin/action-items?exportDomain=")
         .set("Authorization", adminToken);
       expect(res.status).toBe(400);
     });

--- a/api/src/resources/gram/v1/admin/action-items/list.ts
+++ b/api/src/resources/gram/v1/admin/action-items/list.ts
@@ -17,6 +17,12 @@ const isoDate = z
 
 const severityEnum = z.nativeEnum(ThreatSeverity);
 
+/** A single export domain: trimmed, must be non-empty. */
+const exportDomainItem = z
+  .string()
+  .transform((s) => s.trim())
+  .refine((s) => s.length > 0, "must not be empty");
+
 const QuerySchema = z.object({
   systemId: z.union([z.string(), z.array(z.string())]).optional(),
   createdFrom: isoDate.optional(),
@@ -24,7 +30,9 @@ const QuerySchema = z.object({
   reviewApprovedFrom: isoDate.optional(),
   reviewApprovedTo: isoDate.optional(),
   severity: z.union([severityEnum, z.array(severityEnum)]).optional(),
-  exporterKey: z.string().optional(),
+  exportDomain: z
+    .union([exportDomainItem, z.array(exportDomainItem)])
+    .optional(),
   exportStatus: z.enum(["exported", "not-exported"]).optional(),
   limit: z.coerce.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
   offset: z.coerce.number().int().min(0).default(0),
@@ -44,12 +52,6 @@ export function listAdminActionItems(dal: DataAccessLayer) {
     }
     const q = parsed.data;
 
-    const registeredKeys = dal.actionItemHandler.exporters.map((e) => e.key);
-    if (q.exporterKey && !registeredKeys.includes(q.exporterKey)) {
-      res.status(400).json({ error: `Unknown exporterKey: ${q.exporterKey}` });
-      return;
-    }
-
     const systemIds =
       q.systemId === undefined
         ? undefined
@@ -64,8 +66,12 @@ export function listAdminActionItems(dal: DataAccessLayer) {
         ? q.severity
         : [q.severity];
 
-    // Caller resolves the export scope; the service stays agnostic of the registry.
-    const exporterScope = q.exporterKey ? [q.exporterKey] : registeredKeys;
+    const exportDomain =
+      q.exportDomain === undefined
+        ? undefined
+        : Array.isArray(q.exportDomain)
+        ? q.exportDomain
+        : [q.exportDomain];
 
     const filter: ActionItemFilter = {
       systemIds,
@@ -75,7 +81,7 @@ export function listAdminActionItems(dal: DataAccessLayer) {
       reviewApprovedTo: q.reviewApprovedTo,
       severities,
       exportStatus: q.exportStatus as ExportStatusFilter | undefined,
-      exporterScope,
+      exportDomain,
       limit: q.limit,
       offset: q.offset,
     };

--- a/core/src/data/threats/AdminActionItems.spec.ts
+++ b/core/src/data/threats/AdminActionItems.spec.ts
@@ -54,7 +54,6 @@ describe("Admin action item queries", () => {
   }
 
   const baseFilter = {
-    exporterScope: ["wikibase"],
     limit: 50,
     offset: 0,
   };
@@ -129,17 +128,44 @@ describe("Admin action item queries", () => {
       expect(items[0].exportLinks[0].url).toBe("https://wb/Q1");
     });
 
-    it("does NOT count a user-added link as exported", async () => {
+    it("counts a user-added link as exported (created_by is unreliable)", async () => {
       const modelId = await createModel("sys-a");
       const ai = await createActionItem(modelId);
       await dal.linkService.insertLink(
         LinkObjectType.Threat,
         ai.id!,
         "label",
-        "https://ref",
+        "https://jira.com/browse/ABC-1",
         "",
         "alice@klarna.com" // user sub, not an exporter key
       );
+
+      const { items } = await data.listActionItemsFiltered(baseFilter);
+      expect(items[0].exported).toBe(true);
+      expect(items[0].exportLinks).toHaveLength(1);
+      expect(items[0].exportLinks[0].url).toBe("https://jira.com/browse/ABC-1");
+    });
+
+    it("counts a link from a removed exporter as exported", async () => {
+      const modelId = await createModel("sys-a");
+      const ai = await createActionItem(modelId);
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        ai.id!,
+        "label",
+        "https://old/Q1",
+        "",
+        "removed-exporter" // key no longer registered
+      );
+
+      const { items } = await data.listActionItemsFiltered(baseFilter);
+      expect(items[0].exported).toBe(true);
+      expect(items[0].exportLinks).toHaveLength(1);
+    });
+
+    it("treats an item with no links as not exported", async () => {
+      const modelId = await createModel("sys-a");
+      await createActionItem(modelId);
 
       const { items } = await data.listActionItemsFiltered(baseFilter);
       expect(items[0].exported).toBe(false);
@@ -199,6 +225,139 @@ describe("Admin action item queries", () => {
         exported.id
       );
       expect(onlyMissing.items).toHaveLength(1);
+    });
+
+    async function actionItemWithLink(
+      modelId: string,
+      url: string,
+      createdBy = "alice@klarna.com"
+    ): Promise<Threat> {
+      const ai = await createActionItem(modelId);
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        ai.id!,
+        "l",
+        url,
+        "",
+        createdBy
+      );
+      return ai;
+    }
+
+    it("exportDomain matches the exact host and subdomains, not look-alikes", async () => {
+      const modelId = await createModel("sys-a");
+      const exact = await actionItemWithLink(
+        modelId,
+        "https://jira.com/browse/ABC-1"
+      );
+      const sub = await actionItemWithLink(
+        modelId,
+        "https://team.jira.com/browse/ABC-2"
+      );
+      await actionItemWithLink(modelId, "https://notjira.com/x");
+      await actionItemWithLink(modelId, "https://jira.com.evil/x");
+
+      const { items } = await data.listActionItemsFiltered({
+        ...baseFilter,
+        exportDomain: ["jira.com"],
+        exportStatus: "exported",
+      });
+      expect(items.map((i) => i.threat.id).sort()).toEqual(
+        [exact.id, sub.id].sort()
+      );
+    });
+
+    it("exportDomain not-exported returns items without a matching-host link", async () => {
+      const modelId = await createModel("sys-a");
+      await actionItemWithLink(modelId, "https://jira.com/browse/ABC-1");
+      const other = await actionItemWithLink(modelId, "https://example.com/x");
+      const none = await createActionItem(modelId);
+
+      const { items } = await data.listActionItemsFiltered({
+        ...baseFilter,
+        exportDomain: ["jira.com"],
+        exportStatus: "not-exported",
+      });
+      expect(items.map((i) => i.threat.id).sort()).toEqual(
+        [other.id, none.id].sort()
+      );
+    });
+
+    it("exportLinks returns ALL links even when exportDomain is set", async () => {
+      const modelId = await createModel("sys-a");
+      const ai = await createActionItem(modelId);
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        ai.id!,
+        "l1",
+        "https://jira.com/browse/ABC-1",
+        "",
+        "alice@klarna.com"
+      );
+      await dal.linkService.insertLink(
+        LinkObjectType.Threat,
+        ai.id!,
+        "l2",
+        "https://example.com/x",
+        "",
+        "alice@klarna.com"
+      );
+
+      const { items } = await data.listActionItemsFiltered({
+        ...baseFilter,
+        exportDomain: ["jira.com"],
+      });
+      expect(items).toHaveLength(1);
+      expect(items[0].exported).toBe(true);
+      expect(items[0].exportLinks.map((l) => l.url).sort()).toEqual(
+        ["https://example.com/x", "https://jira.com/browse/ABC-1"].sort()
+      );
+    });
+
+    it("matches a domain literally (LIKE wildcards are not special) and handles userinfo/port", async () => {
+      const modelId = await createModel("sys-a");
+      const withPort = await actionItemWithLink(
+        modelId,
+        "https://user@jira.com:443/x"
+      );
+      // A literal "%" in the domain must not act as a wildcard host match.
+      await actionItemWithLink(modelId, "https://jira.com/x");
+
+      const portMatch = await data.listActionItemsFiltered({
+        ...baseFilter,
+        exportDomain: ["jira.com"],
+        exportStatus: "exported",
+      });
+      expect(portMatch.items.map((i) => i.threat.id)).toContain(withPort.id);
+
+      const wildcard = await data.listActionItemsFiltered({
+        ...baseFilter,
+        exportDomain: ["j%.com"],
+        exportStatus: "exported",
+      });
+      expect(wildcard.items).toHaveLength(0);
+    });
+
+    it("matches a link host against ANY of several exportDomains", async () => {
+      const modelId = await createModel("sys-a");
+      const jira = await actionItemWithLink(
+        modelId,
+        "https://jira.com/browse/ABC-1"
+      );
+      const github = await actionItemWithLink(
+        modelId,
+        "https://sub.github.com/x"
+      );
+      await actionItemWithLink(modelId, "https://example.com/x");
+
+      const { items } = await data.listActionItemsFiltered({
+        ...baseFilter,
+        exportDomain: ["jira.com", "github.com"],
+        exportStatus: "exported",
+      });
+      expect(items.map((i) => i.threat.id).sort()).toEqual(
+        [jira.id, github.id].sort()
+      );
     });
 
     it("filters by severity (one or many)", async () => {

--- a/core/src/data/threats/ThreatDataService.ts
+++ b/core/src/data/threats/ThreatDataService.ts
@@ -34,10 +34,12 @@ export type ExportStatusFilter = "exported" | "not-exported";
 
 /**
  * Filter for the admin cross-system action item query.
- * `exporterScope` is resolved by the caller (route handler): `[exporterKey]` when
- * a specific exporter is requested, otherwise the full set of registered exporter
- * keys. The same scope drives both the export-status filter and the `exported`
- * flag / `exportLinks` returned per row.
+ * Export status is derived from the presence of links on the item, regardless of
+ * `created_by`. When `exportDomain` is set, an item only counts as exported (and
+ * passes the `exportStatus` filter) when it has a link whose URL host equals, or
+ * is a subdomain of, ANY of the supplied domains — a true host match.
+ * `exportLinks` always returns every link on the item, independent of
+ * `exportDomain`.
  */
 export interface ActionItemFilter {
   systemIds?: string[];
@@ -47,7 +49,7 @@ export interface ActionItemFilter {
   reviewApprovedTo?: string;
   severities?: ThreatSeverity[];
   exportStatus?: ExportStatusFilter;
-  exporterScope: string[];
+  exportDomain?: string[]; // optional host filter, e.g. ["jira.com", "github.com"]
   limit: number;
   offset: number;
 }
@@ -62,8 +64,8 @@ export interface AdminActionItem {
   threat: Threat;
   systemId: string | null;
   reviewApprovedAt: number | null; // ms
-  exported: boolean; // scoped to ActionItemFilter.exporterScope
-  exportLinks: ActionItemExportLink[];
+  exported: boolean; // has a (matching, when exportDomain is set) link
+  exportLinks: ActionItemExportLink[]; // all links on the item
 }
 
 export class ThreatDataService extends EventEmitter {
@@ -234,23 +236,38 @@ export class ThreatDataService extends EventEmitter {
   /**
    * Admin cross-system action item query (Endpoint 1). Pure data query over
    * threats / models / reviews / links — applies no exporter skip logic.
-   * "exported" = the threat has a links row whose created_by is in
-   * filter.exporterScope (exporter-created links only; user links don't count).
+   * "exported" = the threat has at least one links row (regardless of
+   * created_by); when filter.exportDomain is set, only links whose URL host
+   * equals or is a subdomain of ANY supplied domain count. exportLinks always
+   * returns every link on the item.
    */
   async listActionItemsFiltered(
     filter: ActionItemFilter
   ): Promise<{ total: number; items: AdminActionItem[] }> {
+    // Lowercased domains for the host `=` comparison; a matching set of
+    // subdomain LIKE patterns (`%.<domain>`) with LIKE wildcards (`\`, `%`, `_`)
+    // escaped so each domain is matched literally. An item matches when a link
+    // host equals or is a subdomain of ANY supplied domain.
+    const exportDomains =
+      filter.exportDomain && filter.exportDomain.length > 0
+        ? filter.exportDomain.map((d) => d.toLowerCase())
+        : null;
+    const exportDomainPatterns = exportDomains
+      ? exportDomains.map((d) => "%." + d.replace(/([\\%_])/g, "\\$1"))
+      : null;
+
     const params: any[] = [
-      filter.exporterScope, // $1 — used in the LATERAL
-      filter.systemIds ?? null, // $2
-      filter.createdFrom ?? null, // $3
-      filter.createdTo ?? null, // $4
-      filter.reviewApprovedFrom ?? null, // $5
-      filter.reviewApprovedTo ?? null, // $6
-      filter.exportStatus ?? null, // $7
-      filter.limit, // $8
-      filter.offset, // $9
-      filter.severities ?? null, // $10
+      exportDomains, // $1 — host equality set + presence gate
+      exportDomainPatterns, // $2 — escaped subdomain LIKE patterns
+      filter.systemIds ?? null, // $3
+      filter.createdFrom ?? null, // $4
+      filter.createdTo ?? null, // $5
+      filter.reviewApprovedFrom ?? null, // $6
+      filter.reviewApprovedTo ?? null, // $7
+      filter.exportStatus ?? null, // $8
+      filter.limit, // $9
+      filter.offset, // $10
+      filter.severities ?? null, // $11
     ];
 
     const query = `
@@ -268,7 +285,7 @@ export class ThreatDataService extends EventEmitter {
         t.severity,
         m.system_id,
         extract(epoch from r.approved_at) as review_approved_at,
-        COALESCE(l.exported, false) as exported,
+        COALESCE(l.matched, false) as exported,
         COALESCE(l.links, '[]'::json) as export_links,
         COUNT(*) OVER() as total
       FROM threats t
@@ -276,30 +293,42 @@ export class ThreatDataService extends EventEmitter {
       LEFT JOIN reviews r ON r.model_id = t.model_id
       LEFT JOIN LATERAL (
         SELECT
-          count(*) > 0 as exported,
+          CASE
+            WHEN $1::text[] IS NULL THEN count(*) > 0
+            ELSE COALESCE(bool_or(
+              tl.host = ANY($1::text[])
+              OR tl.host LIKE ANY($2::text[])
+            ), false)
+          END as matched,
           json_agg(json_build_object(
-            'url', url,
-            'createdBy', created_by,
-            'createdAt', extract(epoch from created_at)
+            'url', tl.url,
+            'createdBy', tl.created_by,
+            'createdAt', extract(epoch from tl.created_at)
           )) as links
-        FROM links
-        WHERE object_type = 'threat'
-          AND object_id = t.id::text
-          AND created_by = ANY($1::varchar[])
+        FROM (
+          SELECT
+            url,
+            created_by,
+            created_at,
+            lower(substring(url from '://(?:[^@/?#]*@)?([^:/?#]+)')) as host
+          FROM links
+          WHERE object_type = 'threat'
+            AND object_id = t.id::text
+        ) tl
       ) l ON true
       WHERE t.is_action_item = true
         AND t.deleted_at IS NULL
-        AND ($2::varchar[] IS NULL OR m.system_id = ANY($2::varchar[]))
-        AND ($3::timestamptz IS NULL OR t.created_at >= $3::timestamptz)
-        AND ($4::timestamptz IS NULL OR t.created_at <= $4::timestamptz)
-        AND ($5::timestamptz IS NULL OR r.approved_at >= $5::timestamptz)
-        AND ($6::timestamptz IS NULL OR r.approved_at <= $6::timestamptz)
-        AND ($10::varchar[] IS NULL OR t.severity = ANY($10::varchar[]))
-        AND ($7::text IS NULL
-          OR ($7 = 'exported' AND l.exported)
-          OR ($7 = 'not-exported' AND NOT l.exported))
+        AND ($3::varchar[] IS NULL OR m.system_id = ANY($3::varchar[]))
+        AND ($4::timestamptz IS NULL OR t.created_at >= $4::timestamptz)
+        AND ($5::timestamptz IS NULL OR t.created_at <= $5::timestamptz)
+        AND ($6::timestamptz IS NULL OR r.approved_at >= $6::timestamptz)
+        AND ($7::timestamptz IS NULL OR r.approved_at <= $7::timestamptz)
+        AND ($11::varchar[] IS NULL OR t.severity = ANY($11::varchar[]))
+        AND ($8::text IS NULL
+          OR ($8 = 'exported' AND COALESCE(l.matched, false))
+          OR ($8 = 'not-exported' AND NOT COALESCE(l.matched, false)))
       ORDER BY t.created_at DESC
-      LIMIT $8::int OFFSET $9::int
+      LIMIT $9::int OFFSET $10::int
     `;
 
     const res = await this.pool.query(query, params);


### PR DESCRIPTION
## Summary
- Replace `exporterKey` query param with `exportDomain` for admin action item listing
- Treat any link as exported (not only exporter-created links), with optional host/domain filtering
- Match exact host and subdomains; support multiple `exportDomain` values (ANY match)

## Test plan
- [ ] `npm -w @gram/core test -- core/src/data/threats/AdminActionItems.spec.ts`
- [ ] `npm -w @gram/api test -- api/src/resources/gram/v1/admin/action-items/admin-action-items.spec.ts`