### PR TITLE
feat(core): expose modelId and system in review notification variables

### DIFF
--- a/core/src/data/reviews/reviewNotificationVariables.ts
+++ b/core/src/data/reviews/reviewNotificationVariables.ts
@@ -22,7 +22,7 @@ Please set your team's email address so notifications can reach the right people
 function missingTeamEmail(owner: any, review: Review): string | null {
   if (!owner.email || owner.email === "UNDEFINED") {
     log.warn(
-      `Templating a notification for modelId: ${review.modelId}, but email for owner ${owner.name} is not set or undefined (value: ${owner.email})`,
+      `Templating a notification for modelId: ${review.modelId}, but email for owner ${owner.name} is not set or undefined (value: ${owner.email})`
     );
     return missingTeamEmailWarning(owner.name);
   }
@@ -56,12 +56,12 @@ function getSupportContact(): { name: string; email?: string } | undefined {
  */
 export async function buildReviewNotificationVariables(
   dal: DataAccessLayer,
-  review: Review,
+  review: Review
 ): Promise<NotificationVariables> {
   const model = await dal.modelService.getById(review.modelId);
   if (model === null) {
     throw new Error(
-      `Review object has invalid model id: ${review.modelId}. This should not be possible as all reviews are bound to a model. Help?`,
+      `Review object has invalid model id: ${review.modelId}. This should not be possible as all reviews are bound to a model. Help?`
     );
   }
 
@@ -108,7 +108,7 @@ export async function buildReviewNotificationVariables(
     (async () => {
       const requester = await dal.userHandler.lookupUser(
         {},
-        review.requestedBy,
+        review.requestedBy
       );
       return {
         email: review.requestedBy,
@@ -151,7 +151,7 @@ export async function buildReviewNotificationVariables(
  */
 export async function lookupPreviousReviewer(
   dal: DataAccessLayer,
-  previousReviewer: string | undefined,
+  previousReviewer: string | undefined
 ): Promise<{ name: string; email?: string }> {
   const lookup = previousReviewer
     ? await dal.reviewerHandler.lookupReviewer({}, previousReviewer)

--- a/core/src/data/reviews/reviewNotificationVariables.ts
+++ b/core/src/data/reviews/reviewNotificationVariables.ts
@@ -22,7 +22,7 @@ Please set your team's email address so notifications can reach the right people
 function missingTeamEmail(owner: any, review: Review): string | null {
   if (!owner.email || owner.email === "UNDEFINED") {
     log.warn(
-      `Templating a notification for modelId: ${review.modelId}, but email for owner ${owner.name} is not set or undefined (value: ${owner.email})`
+      `Templating a notification for modelId: ${review.modelId}, but email for owner ${owner.name} is not set or undefined (value: ${owner.email})`,
     );
     return missingTeamEmailWarning(owner.name);
   }
@@ -56,12 +56,12 @@ function getSupportContact(): { name: string; email?: string } | undefined {
  */
 export async function buildReviewNotificationVariables(
   dal: DataAccessLayer,
-  review: Review
+  review: Review,
 ): Promise<NotificationVariables> {
   const model = await dal.modelService.getById(review.modelId);
   if (model === null) {
     throw new Error(
-      `Review object has invalid model id: ${review.modelId}. This should not be possible as all reviews are bound to a model. Help?`
+      `Review object has invalid model id: ${review.modelId}. This should not be possible as all reviews are bound to a model. Help?`,
     );
   }
 
@@ -108,7 +108,7 @@ export async function buildReviewNotificationVariables(
     (async () => {
       const requester = await dal.userHandler.lookupUser(
         {},
-        review.requestedBy
+        review.requestedBy,
       );
       return {
         email: review.requestedBy,
@@ -119,6 +119,7 @@ export async function buildReviewNotificationVariables(
   ]);
 
   const modelInfo = {
+    modelId: review.modelId,
     link: linkToModel(review.modelId),
     name: `${system ? system.displayName + " - " : ""}${model.version}`,
   };
@@ -129,6 +130,7 @@ export async function buildReviewNotificationVariables(
     owner,
     fallbackReviewer,
     contact,
+    system,
     model: modelInfo,
     missingTeamEmail: missingTeamEmail(owner, review),
     review: {
@@ -149,7 +151,7 @@ export async function buildReviewNotificationVariables(
  */
 export async function lookupPreviousReviewer(
   dal: DataAccessLayer,
-  previousReviewer: string | undefined
+  previousReviewer: string | undefined,
 ): Promise<{ name: string; email?: string }> {
   const lookup = previousReviewer
     ? await dal.reviewerHandler.lookupReviewer({}, previousReviewer)


### PR DESCRIPTION
## Summary

- Adds `modelId` to the review notification `model` variables object
- Exposes `system` in the notification template context for provider plugins

## Test plan

- [ ] Verify review notification templates can access `model.modelId` and `system`
- [ ] Confirm existing email notification templates still render correctly


Made with [Cursor](https://cursor.com)