### PR TITLE
fix(logger): merge multi-arg log calls into a single JSON line

### DIFF
--- a/core/src/logger/index.ts
+++ b/core/src/logger/index.ts
@@ -30,37 +30,34 @@ export function configureLogging() {
       payload: {},
     };
 
-    const events = logEvent.data.map((event) => {
-      const line = { ...logLine };
+    for (const event of logEvent.data) {
       if (typeof event === "string") {
-        line.message = event;
-        return line;
+        logLine.message = event;
+        continue;
       }
 
       if (event) {
         if (event.payload) {
-          line.payload = event.payload;
+          logLine.payload = event.payload;
         }
 
         if (event.meta) {
-          line.meta = event.meta;
+          logLine.meta = event.meta;
         }
 
         if (event.correlation_id) {
-          line.correlation_id = event.correlation_id;
+          logLine.correlation_id = event.correlation_id;
         }
 
         // Serialize errors, otherwise JSON.stringify on Error returns {}
         if (event.message && event.stack) {
-          line.message = event.message;
-          line.payload.stack = event.stack;
+          logLine.message = event.message;
+          logLine.payload.stack = event.stack;
         }
       }
+    }
 
-      return line;
-    });
-
-    return events.map((event) => JSON.stringify(event)).join("");
+    return JSON.stringify(logLine);
   });
 
   const log4jconfig: log4js.Configuration = {


### PR DESCRIPTION
## Summary
- The log4js `json` layout mapped each argument of a log call (e.g. `log.warn(message, { payload })`) into its own separate JSON object, then joined the stringified objects with no separator — producing malformed/split output where `message` and `payload` landed in different, concatenated blobs.
- This broke downstream log ingestion, which fell back to dumping the entire raw concatenated text into `log.message` instead of parsing structured fields.
- Fix: merge all arguments of a single log call into one `LogLine` object before serializing, so `log.warn("Failed to send notifications", { payload: { ids } })` now emits one valid JSON line with both `message` and `payload` populated.

## Test plan
- [ ] Restart the backend (core changes require a rebuild) and trigger a log call with both a string and a payload object (e.g. failed notification delivery) — verify stdout emits a single well-formed JSON line with `message` and `payload` both populated.
- [ ] Confirm single-argument log calls (plain string, plain object, Error) still serialize correctly.